### PR TITLE
Unable to close app if it's in background

### DIFF
--- a/group/S60Maps.mmp
+++ b/group/S60Maps.mmp
@@ -56,6 +56,7 @@ LIBRARY		   efsrv.lib
 LIBRARY		   estor.lib
 LIBRARY        aknnotify.lib
 LIBRARY        hlplch.lib lbs.lib gdi.lib imageconversion.lib fbscli.lib bitgdi.lib http.lib bafl.lib inetprotutil.lib remconcoreapi.lib remconinterfacebase.lib ws32.lib charconv.lib hash.lib eikcoctl.lib
+LIBRARY        apgrfx.lib
  
 
 

--- a/src/S60MapsAppUi.cpp
+++ b/src/S60MapsAppUi.cpp
@@ -461,6 +461,7 @@ void CS60MapsAppUi::HandleExitL()
 	TInt WgId = session.GetFocusWindowGroup();
 	CApaWindowGroupName* Wgn = CApaWindowGroupName::NewL(session, WgId);
 	TUid forgroundApp = Wgn->AppUid();
+	delete Wgn;
 	const TUid KAppUid = {_UID3};
 	//If application is in background Symbian OS will show its own quit confirmation.
 	if(forgroundApp == KAppUid)

--- a/src/S60MapsAppUi.cpp
+++ b/src/S60MapsAppUi.cpp
@@ -14,6 +14,7 @@
 #include <stringloader.h>
 #include <s32file.h>
 #include <hlplch.h>
+#include <apgwgnam.h>
 
 #include <S60Maps_0xED689B88.rsg>
 
@@ -456,20 +457,30 @@ void CS60MapsAppUi::MrccatoCommand(TRemConCoreApiOperationId aOperationId,
 
 void CS60MapsAppUi::HandleExitL()
 	{
-	CAknMessageQueryDialog* dlg = new (ELeave) CAknMessageQueryDialog();
-	dlg->PrepareLC(R_CONFIRM_EXIT_QUERY_DIALOG);
-	HBufC* title = iEikonEnv->AllocReadResourceLC(R_CONFIRM_EXIT_DIALOG_TITLE);
-	dlg->QueryHeading()->SetTextL(*title);
-	CleanupStack::PopAndDestroy(); //title
-	HBufC* msg = iEikonEnv->AllocReadResourceLC(R_CONFIRM_EXIT_DIALOG_TEXT);
-	dlg->SetMessageTextL(*msg);
-	CleanupStack::PopAndDestroy(); //msg
-	TInt res = dlg->RunLD();
-	if (res == EAknSoftkeyYes)
+	RWsSession& session = CEikonEnv::Static()->WsSession();
+	TInt WgId = session.GetFocusWindowGroup();
+	CApaWindowGroupName* Wgn = CApaWindowGroupName::NewL(session, WgId);
+	TUid forgroundApp = Wgn->AppUid();
+	const TUid KAppUid = {_UID3};
+	//If application is in background Symbian OS will show its own quit confirmation.
+	if(forgroundApp == KAppUid)
 		{
-		SaveL();
-		Exit();
+		CAknMessageQueryDialog* dlg = new (ELeave) CAknMessageQueryDialog();
+		dlg->PrepareLC(R_CONFIRM_EXIT_QUERY_DIALOG);
+		HBufC* title = iEikonEnv->AllocReadResourceLC(R_CONFIRM_EXIT_DIALOG_TITLE);
+		dlg->QueryHeading()->SetTextL(*title);
+		CleanupStack::PopAndDestroy(); //title
+		HBufC* msg = iEikonEnv->AllocReadResourceLC(R_CONFIRM_EXIT_DIALOG_TEXT);
+		dlg->SetMessageTextL(*msg);
+		CleanupStack::PopAndDestroy(); //msg
+		TInt res = dlg->RunLD();
+		if (res != EAknSoftkeyYes)
+			{
+			return;
+			}
 		}
+	SaveL();
+	Exit();
 	}
 
 void CS60MapsAppUi::HandleFindMeL()


### PR DESCRIPTION
because of the quit confirmation that shows locally in application
window.
When closing an app with the Symbian's taskbar the system shows its
own request, so we need to use the ours quit confirmation only if
S60Mpas is in foreground.