### PR TITLE
Get landmark position before querying its name.

### DIFF
--- a/src/S60MapsAppUi.cpp
+++ b/src/S60MapsAppUi.cpp
@@ -775,21 +775,21 @@ void CS60MapsAppUi::HandleCreateLandmarkL()
 	CleanupClosePushL(landmarkName);
 	landmarkName.Copy(KDefaultLandmarkName);
 	
+	// Create landmark
+	CPosLandmark* newLandmark = CPosLandmark::NewLC();
+	TLocality pos = TLocality(iAppView->GetCenterCoordinate(), KNaN, KNaN);
+	newLandmark->SetPositionL(pos);
 	// Ask landmark name
 	HBufC* dlgTitle = iEikonEnv->AllocReadResourceLC(R_INPUT_NAME);
 	CAknTextQueryDialog* dlg = new (ELeave) CAknTextQueryDialog(landmarkName);
 	if (dlg->ExecuteLD(R_LANDMARK_NAME_INPUT_QUERY, *dlgTitle) == EAknSoftkeyOk)
 		{
 		// Save landmark to DB	
-		CPosLandmark* newLandmark = CPosLandmark::NewLC();
-		TLocality pos = TLocality(iAppView->GetCenterCoordinate(), KNaN, KNaN);
-		newLandmark->SetPositionL(pos);
 		newLandmark->SetLandmarkNameL(landmarkName);
 		iLandmarksDb->AddLandmarkL(*newLandmark);
-		
-		CleanupStack::PopAndDestroy(newLandmark);
 		}
-	
+
+	CleanupStack::PopAndDestroy(newLandmark);
 	CleanupStack::PopAndDestroy(2, &landmarkName);
 	}
 


### PR DESCRIPTION
If a new landmark is being created in portrait orientation but virtual
keyboard (touch ui) is changed to landscape at name entering, the
resulting position of the new landmark differs from the initial.